### PR TITLE
Adapt MongoDBWorker to mspass Client constructor

### DIFF
--- a/python/pwmigpy/dataprep/scripts/pseudosource_stacker.py
+++ b/python/pwmigpy/dataprep/scripts/pseudosource_stacker.py
@@ -670,7 +670,7 @@ def main(args=None):
     if parallel:
         dask_client = mspass_client.get_scheduler()
         print("Creating worker plugin")
-        dbplugin = MongoDBWorker(dbname)
+        dbplugin = MongoDBWorker(mspass_client)
         print("Running register_plugin")
         dask_client.register_plugin(dbplugin)
     # we always require site data to calculate travel times

--- a/python/pwmigpy/pwmig/dataset.py
+++ b/python/pwmigpy/pwmig/dataset.py
@@ -110,7 +110,7 @@ def pwmig_dataset(
     daskclient = mspass_client.get_scheduler()
     if initialize_workers:
         print("Creating worker plugin")
-        dbplugin = MongoDBWorker(dbname)
+        dbplugin = MongoDBWorker(mspass_client)
         print("Running register_plugin")
         daskclient.register_plugin(dbplugin)
     else:
@@ -288,7 +288,7 @@ def pwstack_dataset(
     if parallel:
         if initialize_workers:
             print("Creating worker plugin")
-            dbplugin = MongoDBWorker(dbname)
+            dbplugin = MongoDBWorker(mspass_client)
             print("Running register_plugin")
             daskclient.register_plugin(dbplugin)
         else:


### PR DESCRIPTION
## Summary

Updates `parallel_pwmig` call sites for the **MongoDBWorker** API change in [mspass-team/mspass#709](https://github.com/mspass-team/mspass/pull/709): the plugin now takes an MSPASS `Client` (`get_database_client()` / `_mspass_db_host`) instead of caller-supplied db name / URL.

## Dependency

- **Requires mspass with PR #709 merged** (or equivalent `db_utils.MongoDBWorker(mspass_client, ...)`).
- Recommend merging **mspass #709 first**, then this PR.

## Changes

- `MongoDBWorker(dbname)` → `MongoDBWorker(mspass_client)` where the Dask worker plugin is registered:
  - `python/pwmigpy/dataprep/scripts/pseudosource_stacker.py`
  - `python/pwmigpy/pwmig/dataset.py` (`pwmig_dataset`, `pwstack_dataset`)

`fetch_dbhandle(dbname)` usage on workers is unchanged (still passes the database name string).

## Breaking change

Environments pinned to **older mspass** that still expect `MongoDBWorker(dbname, ...)` must upgrade mspass before upgrading parallel_pwmig.